### PR TITLE
Backport "dwc_otg: add handling of SPLIT transaction data toggle errors"

### DIFF
--- a/drivers/usb/dwc_otg/dwc_otg_hcd.h
+++ b/drivers/usb/dwc_otg/dwc_otg_hcd.h
@@ -634,6 +634,10 @@ static inline uint16_t dwc_micro_frame_num (uint16_t _frame)
 	return (_frame) & 0x7;
 }
 
+void dwc_otg_hcd_save_data_toggle(dwc_hc_t * hc,
+				  dwc_otg_hc_regs_t * hc_regs,
+				  dwc_otg_qtd_t * qtd);
+
 #ifdef DEBUG
 /**
  * Macro to sample the remaining PHY clocks left in the current frame. This


### PR DESCRIPTION
Backport of [dwc_otg patch](https://github.com/P33M/linux/commit/f6769105af7fcd1168da68c1e0f297d4ddcfe558) released for raspberrypi/linux#241
