### PR TITLE
Reduce initial uSD clock frequency

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -155,7 +155,7 @@ dtb-$(CONFIG_ARCH_OMAP2PLUS) += omap2420-h4.dtb \
 	am335x-bone.dtb
 dtb-$(CONFIG_ARCH_ORION5X) += orion5x-lacie-ethernet-disk-mini-v2.dtb
 dtb-$(CONFIG_ARCH_PRIMA2) += prima2-evb.dtb
-dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3188-tb.dtb
+dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3188-tb.dtb radxa-rock2-square.dtb
 dtb-$(CONFIG_ARCH_U8500) += snowball.dtb \
 	hrefprev60.dtb \
 	hrefv60plus.dtb \

--- a/arch/arm/boot/dts/radxa-rock2-square.dts
+++ b/arch/arm/boot/dts/radxa-rock2-square.dts
@@ -259,7 +259,7 @@
 };
     
 &sdmmc {
-		clock-frequency = <50000000>;
+		clock-frequency = <25000000>;
 		lock-freq-min-max = <400000 50000000>;
 		supports-highspeed;
 		supports-sd;

--- a/block/partitions/mtdpart.c
+++ b/block/partitions/mtdpart.c
@@ -342,6 +342,8 @@ int mtdpart_partition(struct parsed_partitions *state)
         	return 0;
 
 	cmdline = strstr(saved_command_line, "mtdparts=") + 9;
+	if(cmdline - 9 == NULL)
+		return 0;
 	
 	num_parts = parse_cmdline_partitions(n, &parts, 0);
 	if(num_parts < 0)

--- a/drivers/usb/dwc_otg_310/dwc_otg_hcd.c
+++ b/drivers/usb/dwc_otg_310/dwc_otg_hcd.c
@@ -444,7 +444,7 @@ static int dwc_otg_hcd_sleep_cb(void *p)
  *
  * @param p void pointer to the <code>struct usb_hcd</code>
  */
-extern inline struct usb_hcd *dwc_otg_hcd_to_hcd(dwc_otg_hcd_t *dwc_otg_hcd);
+extern struct usb_hcd *dwc_otg_hcd_to_hcd(dwc_otg_hcd_t *dwc_otg_hcd);
 static int dwc_otg_hcd_rem_wakeup_cb(void *p)
 {
 	dwc_otg_hcd_t *dwc_otg_hcd = p;

--- a/drivers/usb/dwc_otg_310/dwc_otg_hcd_intr.c
+++ b/drivers/usb/dwc_otg_310/dwc_otg_hcd_intr.c
@@ -308,7 +308,7 @@ int32_t dwc_otg_hcd_handle_perio_tx_fifo_empty_intr(dwc_otg_hcd_t *dwc_otg_hcd)
 	return 1;
 }
 
-extern inline struct usb_hcd *dwc_otg_hcd_to_hcd(dwc_otg_hcd_t *dwc_otg_hcd);
+extern struct usb_hcd *dwc_otg_hcd_to_hcd(dwc_otg_hcd_t *dwc_otg_hcd);
 /** There are multiple conditions that can cause a port interrupt. This function
  * determines which interrupt conditions have occurred and handles them
  * appropriately. */


### PR DESCRIPTION
The default clock frequency for SD is 25MHz. Cheap uSD cards (like mine) will throw errors if they are driven at 50MHz. For cards that do support a higher clock frequency, the driver can query the parameters of the card and adjust the frequency (and voltage) as desired.

I have also snuck a few extra trivial fixes into this pull request.
